### PR TITLE
Added packet support for 1.13.1.

### DIFF
--- a/bungee/src/main/java/de/themoep/resourcepacksplugin/bungee/packets/ResourcePackSendPacket.java
+++ b/bungee/src/main/java/de/themoep/resourcepacksplugin/bungee/packets/ResourcePackSendPacket.java
@@ -52,7 +52,8 @@ public class ResourcePackSendPacket extends DefinedPacket {
             new IdMapping("1.12", ProtocolConstants.MINECRAFT_1_12, 0x33),
             new IdMapping("1.12.1", ProtocolConstants.MINECRAFT_1_12_1, 0x34),
             new IdMapping("1.12.2", ProtocolConstants.MINECRAFT_1_12_2, 0x34),
-            new IdMapping("1.13", ProtocolConstants.MINECRAFT_1_13, 0x37)
+            new IdMapping("1.13", ProtocolConstants.MINECRAFT_1_13, 0x37),
+            new IdMapping("1.13.1", ProtocolConstants.MINECRAFT_1_13_1, 0x37)
     );
 
     public ResourcePackSendPacket() {};
@@ -88,7 +89,7 @@ public class ResourcePackSendPacket extends DefinedPacket {
             throw new UnsupportedOperationException("Only players can receive ResourcePackSend packets!");
         }
     }
-    
+
     public void relayPacket(UserConnection usercon, PacketWrapper packet) throws Exception {
         BungeeResourcepacks plugin = BungeeResourcepacks.getInstance();
         if(plugin.isEnabled()) {


### PR DESCRIPTION
Updated the pull request in respect to the current formatting of the authored code.

I could not run the bungeecord plug-in due to a bad packet error upon logging into my local network as seen here in this screenshot:
![image](https://user-images.githubusercontent.com/1055689/47007856-c0d11a80-d0fe-11e8-8d20-eed91f02273d.png)

The plug-in will not operate properly without this fix for my current setup. I am currently using a build from BungeeCord that is a few days old from this post, and am using 1.13.1 with the development build of Spigot.
